### PR TITLE
Add support for modern Workday and Glassdoor URL patterns

### DIFF
--- a/api/src/services/__tests__/jobParser.test.ts
+++ b/api/src/services/__tests__/jobParser.test.ts
@@ -43,6 +43,7 @@ describe('JobParser', () => {
 		'https://boards.greenhouse.io/company/jobs/12345',
 		'https://jobs.lever.co/company/position-id',
 		'https://company.myworkdayjobs.com/en-US/careers/job/12345',
+		'https://wd1.myworkdaysite.com/recruiting/company/careers/job/12345',
 		'https://careers.google.com/jobs/results/12345',
 		'https://careers.google.com/jobs/results/99999',
 		'https://www.linkedin.com/jobs/view/deleted',
@@ -75,6 +76,7 @@ describe('JobParser', () => {
 
 		it('should validate Glassdoor job URLs', async () => {
 			expect(await jobParser.isSupported('https://www.glassdoor.com/job-listing/software-engineer')).toBe(true)
+			expect(await jobParser.isSupported('https://www.glassdoor.com/job/software-engineer')).toBe(true)
 		})
 
 		it('should validate Greenhouse job URLs', async () => {
@@ -87,6 +89,7 @@ describe('JobParser', () => {
 
 		it('should validate Workday job URLs', async () => {
 			expect(await jobParser.isSupported('https://company.myworkdayjobs.com/en-US/careers/job/12345')).toBe(true)
+			expect(await jobParser.isSupported('https://wd1.myworkdaysite.com/recruiting/company/careers/job/12345')).toBe(true)
 		})
 
 		it('should reject non-job URLs', async () => {
@@ -116,6 +119,7 @@ describe('JobParser', () => {
 			expect(domains).toContain('glassdoor.com')
 			expect(domains).toContain('greenhouse.io')
 			expect(domains).toContain('lever.co')
+			expect(domains).toContain('myworkdaysite.com')
 			expect(Array.isArray(domains)).toBe(true)
 			expect(domains.length).toBeGreaterThan(0)
 		})

--- a/api/src/services/jobParser.ts
+++ b/api/src/services/jobParser.ts
@@ -40,6 +40,7 @@ const ALLOWED_DOMAINS = [
 	'greenhouse.io',
 	'lever.co',
 	'myworkdayjobs.com',
+	'myworkdaysite.com',
 	'ashbyhq.com',
 	'jobs.lever.co',
 	'boards.greenhouse.io',
@@ -462,7 +463,7 @@ class JobParser {
 		}
 
 		if (hostname.endsWith('glassdoor.com')) {
-			return path.includes('/job-listing/')
+			return path.includes('/job-listing/') || path.includes('/job/')
 		}
 
 		if (hostname.endsWith('greenhouse.io')) {
@@ -473,7 +474,7 @@ class JobParser {
 			return path.split('/').filter(Boolean).length >= 2
 		}
 
-		if (hostname.endsWith('myworkdayjobs.com')) {
+		if (hostname.endsWith('myworkdayjobs.com') || hostname.endsWith('myworkdaysite.com')) {
 			return path.includes('/job/')
 		}
 

--- a/api/src/services/parsers/ats.ts
+++ b/api/src/services/parsers/ats.ts
@@ -54,7 +54,7 @@ export class WorkdayParser implements JobParserStrategy {
 	name = 'workday'
 
 	canParse(url: string): boolean {
-		return url.includes('myworkdayjobs.com')
+		return url.includes('myworkdayjobs.com') || url.includes('myworkdaysite.com')
 	}
 
 	parse($: cheerio.CheerioAPI): Partial<ParsedJobData> {


### PR DESCRIPTION
### Motivation
- The parser rejected or mis-routed some real job posting URLs (modern Workday hosts and alternate Glassdoor paths), causing valid postings to never reach the specialized parsers. 
- Improve pre-parse URL validation and strategy selection so known Job ATS formats are parsed by their intended strategies rather than the generic fallback.

### Description
- Added `myworkdaysite.com` to the parser allowlist so Workday-hosted postings on that domain are considered allowed (`api/src/services/jobParser.ts`).
- Updated job URL validation to accept Glassdoor `/job/` paths in addition to `/job-listing/` so more Glassdoor postings are recognized (`api/src/services/jobParser.ts`).
- Updated the Workday strategy routing so `WorkdayParser.canParse` returns true for `myworkdaysite.com` hosts (`api/src/services/parsers/ats.ts`).
- Extended unit tests to cover the new Workday domain and Glassdoor path patterns and to assert the supported domain list contains `myworkdaysite.com` (`api/src/services/__tests__/jobParser.test.ts`).

### Testing
- Ran the parser test suite with `cd api && npm test -- src/services/__tests__/jobParser.test.ts`, and the Vitest run completed successfully with all tests passing (1 test file, 29 tests passed).
- The test run reported DNS lookup warnings for unreachable hostnames during validation checks, but the automated tests still passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3b4bb54e883288ac5603aeed73ec1)